### PR TITLE
Compile on Linux with ESP32 2.0.0 Board Manager

### DIFF
--- a/src/commands/LX200.cpp
+++ b/src/commands/LX200.cpp
@@ -2,6 +2,11 @@
 // LX200 command processing
 
 #include <stdint.h>
+
+#ifdef ESP32
+#define PROGMEM
+#endif
+
 #include <Ephemeris.h> // https://github.com/MarScaper/ephemeris
 #include "../catalogs/Catalog.h"
 #include "../userInterface/UserInterface.h"

--- a/src/commands/LX200.cpp
+++ b/src/commands/LX200.cpp
@@ -1,6 +1,7 @@
 // -----------------------------------------------------------------------------------
 // LX200 command processing
 
+#include <stdint.h>
 #include <Ephemeris.h> // https://github.com/MarScaper/ephemeris
 #include "../catalogs/Catalog.h"
 #include "../userInterface/UserInterface.h"

--- a/src/userInterface/menus/MenuAlignment.cpp
+++ b/src/userInterface/menus/MenuAlignment.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------
 // MenuAlignment, for UserInterface
-#include "..\UserInterface.h"
+#include "../UserInterface.h"
 
 void UI::menuAlignment()
 {

--- a/src/userInterface/menus/MenuMain.cpp
+++ b/src/userInterface/menus/MenuMain.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------
 // MenuMain, for UserInterface
-#include "..\UserInterface.h"
+#include "../UserInterface.h"
 
 void UI::menuFeatureKey() {
   static unsigned short current_selection_feature_mode = 1;

--- a/src/userInterface/menus/MenuMount.cpp
+++ b/src/userInterface/menus/MenuMount.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------
 // MenuMount, for UserInterface
-#include "..\UserInterface.h"
+#include "../UserInterface.h"
 
 void UI::menuMount() {
   current_selection_L2 = 1;

--- a/src/userInterface/menus/MenuSettings.cpp
+++ b/src/userInterface/menus/MenuSettings.cpp
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------
 // MenuSettings, for UserInterface
-#include "..\UserInterface.h"
+#include "../UserInterface.h"
 extern NVS nv;
 
 void UI::menuSettings() {


### PR DESCRIPTION
Changes needed to make the SHC compile, and run, on Linux with the ESP32 2.0.0 Board Manager. 

Tested. 