### PR TITLE
Add Spiral Scan & Switches support to SHC

### DIFF
--- a/src/libApp/status/Status.cpp
+++ b/src/libApp/status/Status.cpp
@@ -254,6 +254,26 @@ int Status::getFocuserCount() {
   return focuserCount;
 }
 
+bool Status::hasSwitch(int n) {
+  if (n < 0 || n > 2) return false;
+  static bool processed = false;
+  static bool switches[3] = {false, false, false};
+  if (!processed) {
+    char out[40];
+      if ((onStep.Get(":GXX1#", out) == CR_VALUE_GET)) switches[0] = (out[1] == '#');
+      if ((onStep.Get(":GXX2#", out) == CR_VALUE_GET)) switches[1] = (out[1] == '#');
+      if ((onStep.Get(":GXX3#", out) == CR_VALUE_GET)) switches[2] = (out[1] == '#');
+
+    for (int i = 0; i < 3; i++) { if (switches[i]) switchCount++; }
+    processed = true;
+  }
+  return switches[n];
+}
+
+int Status::getSwitchCount() {
+  return switchCount;
+}
+
 static int _rotator  = -1;
 static int _derotator  = -1;
 bool Status::hasRotator() {

--- a/src/libApp/status/Status.h
+++ b/src/libApp/status/Status.h
@@ -65,6 +65,8 @@ public:
   int getOnStepVersion();
   bool hasFocuser(int n);
   int getFocuserCount();
+  bool hasSwitch(int n);
+  int getSwitchCount();
   bool hasRotator();
   bool hasDeRotator();
   bool hasReticle();
@@ -109,4 +111,5 @@ public:
 
 private:
   int focuserCount = 0;
+  int switchCount = 0;
 };

--- a/src/locales/Strings_en.h
+++ b/src/locales/Strings_en.h
@@ -248,6 +248,7 @@
 #define L_SG_HOME "Home"
 #define L_SG_SYNC "Sync"
 #define L_SG_GOTO "Goto"
+#define L_SG_SPIRAL "Spiral Search"
 
 // return home or reset at home
 #define L_SG_HOME1 "Goto Home will"

--- a/src/locales/Strings_en.h
+++ b/src/locales/Strings_en.h
@@ -85,6 +85,7 @@
 #define L_FKEY_RETICLE "Reticle"
 #define L_FKEY_FOCUSER "Focuser"
 #define L_FKEY_ROTATOR "Rotator"
+#define L_FKEY_SWITCH "Switch"
 #define L_FKEY_FEATURE_KEYS "Feature Keys"
 
 // main menu root

--- a/src/userInterface/UserInterface.cpp
+++ b/src/userInterface/UserInterface.cpp
@@ -314,6 +314,15 @@ void UI::poll() {
         else if (focusState == FS_IN_SLOW  && keyPad.f->isDown() && keyPad.f->timeDown() > 5000) { focusState = FS_IN_FAST;  SERIAL_ONSTEP.print(":FF#:F-#"); message.brief(L_FKEY_FOCF_UP); }
       #endif
     break;
+
+    // switches
+    case 12: case 13: case 14: case 15: case 16: case 17: case 18: case 19:
+	  char cmd[] = ":SXX_,V_#";
+	  cmd[4] = '1' + featureKeyMode - 12;
+	  const char current_switch[] = { cmd[4], '\n' };
+      if (keyPad.F->wasPressed()) { cmd[7] = '0'; SERIAL_ONSTEP.print(cmd); message.show(L_FKEY_SWITCH, L_OFF, current_switch, 1000); } else
+      if (keyPad.f->wasPressed()) { cmd[7] = '1'; SERIAL_ONSTEP.print(cmd); message.show(L_FKEY_SWITCH, L_ON, current_switch, 1000); }
+    break;
   }
   if (buttonCommand) { time_last_action = millis(); return; }
 

--- a/src/userInterface/menus/MenuMain.cpp
+++ b/src/userInterface/menus/MenuMain.cpp
@@ -42,7 +42,7 @@ void UI::menuFeatureKey() {
   char string_feature_Modes[120] = L_FKEY_GUIDE_RATE "\n" L_FKEY_PULSE_GUIDE_RATE;
 
   int i = 2;
-  int j[9] = {-1, -1, -1, -1, -1, -1, -1, -1, -1};
+  int j[17] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
   #if UTILITY_LIGHT != OFF
     { i++; j[0]=i; strcat(string_feature_Modes,"\n" L_FKEY_UTILITY_LIGHT); }
   #endif
@@ -56,6 +56,17 @@ void UI::menuFeatureKey() {
       strcat(string_feature_Modes,"\n" L_FKEY_FOCUSER);
       nums[0] = '1' + n;
       if (status.getFocuserCount() > 1) { strcat(string_feature_Modes, " "); strcat(string_feature_Modes, nums); }
+    }
+  }
+
+  for (int n = 0; n < 8; n++) {
+    char nums[] = "0";
+    if (status.hasSwitch(n)) {
+      i++;
+      j[n + 9] = i;
+	  nums[0] = '1' + n;
+      strcat(string_feature_Modes,"\n" L_FKEY_SWITCH " ");
+	  strcat(string_feature_Modes, nums);
     }
   }
 
@@ -73,6 +84,14 @@ void UI::menuFeatureKey() {
     if (current_selection_feature_mode == j[6]) { featureKeyMode = 9; onStep.Set(":FA4#"); } else // focuser 4
     if (current_selection_feature_mode == j[7]) { featureKeyMode = 10; onStep.Set(":FA5#"); } else // focuser 5
     if (current_selection_feature_mode == j[8]) { featureKeyMode = 11; onStep.Set(":FA6#"); } else // focuser 6
+	if (current_selection_feature_mode == j[9]) featureKeyMode = 12; else // switch 1
+	if (current_selection_feature_mode == j[10]) featureKeyMode = 13; else // switch 2
+	if (current_selection_feature_mode == j[11]) featureKeyMode = 14; else // switch 3
+	if (current_selection_feature_mode == j[9]) featureKeyMode = 15; else // switch 4
+	if (current_selection_feature_mode == j[10]) featureKeyMode = 16; else // switch 5
+	if (current_selection_feature_mode == j[11]) featureKeyMode = 17; else // switch 6
+	if (current_selection_feature_mode == j[9]) featureKeyMode = 18; else // switch 7
+	if (current_selection_feature_mode == j[10]) featureKeyMode = 19; else // switch 8
     { featureKeyMode = 1; current_selection_feature_mode = 1; } // default to guide rate
   } else current_selection_feature_mode = last_selection_feature_mode;
 }

--- a/src/userInterface/menus/MenuSyncGoto.cpp
+++ b/src/userInterface/menus/MenuSyncGoto.cpp
@@ -34,7 +34,7 @@ MENU_RESULT UI::menuSyncGoto(bool sync) {
     }
     // add the normal filtering, solarsys, etc. items
     strcat(string_list_gotoL1,L_SG_SOLSYS ">" "\n");
-    if (sync) strcat(string_list_gotoL1,L_SG_HERE ">"); else strcat(string_list_gotoL1,L_SG_USER ">" "\n" L_SG_FILTERS "\n" L_SG_COORDS "\n" L_SG_HOME);
+    if (sync) strcat(string_list_gotoL1,L_SG_HERE ">"); else strcat(string_list_gotoL1,L_SG_USER ">" "\n" L_SG_FILTERS "\n" L_SG_COORDS "\n" L_SG_SPIRAL "\n" L_SG_HOME);
 
     int selection = display->UserInterfaceSelectionList(&keyPad, sync ? L_SG_SYNC : L_SG_GOTO, current_selection, string_list_gotoL1);
     if (selection == 0) return MR_CANCEL;
@@ -63,6 +63,15 @@ MENU_RESULT UI::menuSyncGoto(bool sync) {
         if (menuRADec(sync) == MR_QUIT) return MR_QUIT;
       break;
       case 5:
+	  {
+		message.show(L_SG_SPIRAL, "", 2000);
+        onStep.Set(":Mp#");
+        message.show(L_SG_SPIRAL, "...", -1);
+        onStep.Set(":Q#");
+		return MR_QUIT;
+	  }
+      break;
+      case 6:
       {
         bool GotoHome = false;
         message.show(L_SG_HOME1, L_SG_HOME2, 2000);


### PR DESCRIPTION
Add Spiral Scan menu option in GOTO page.
It would be nice if OnStep responded with some confirmation after the :Mp# command, because there is no way from SHC to know if scan started or not (e.g. because it was not aligned).

Add OnStep Switches as Feature keys (left button OFF, right button ON).

![SHC Switch Spiral Search](https://user-images.githubusercontent.com/14005124/142785649-30a86a8d-a695-4d02-bf66-6d9a87c6580b.jpg)
