### PR TITLE
Continuous slew mode (satellite tracking)

### DIFF
--- a/src/userInterface/UserInterface.h
+++ b/src/userInterface/UserInterface.h
@@ -144,6 +144,16 @@ private:
   bool moveEast = false;
   bool moveWest = false;
 
+  bool enableSlewMultiMode = false;
+  float slewRatioN = 3;
+  enum LastDirButton{NONE, NS, WE};
+  LastDirButton lastDirButton = NONE;
+  float slewRatioW = 3;
+  float magicCoef = 3;
+  const float sidereal = 0.0042;
+  float Wspeed = 10*sidereal;
+  float Nspeed = 10*sidereal;
+
   // Guide commands
   char ccMe[5];
   char ccMw[5];


### PR DESCRIPTION
Hey, first of all I hope this is the correct place for discussion, I want to check if there is any interest of using code I'm using, so...

I've added new continuous slew mode - The idea is to be able to track satellites, airplanes, timelapse panning photography and possibly others.

Explanation of how it works using example:
1. hold down f+F - it will switch to new mode
2. click W - it starts sleewing at constant rate, supose 0.1 deg/s
3. click W again - it will increase the speed to 0.3 deg/s (0.1*3)
4. click F - multiplier decreases from 3 to 3/2
5. click W again - speed is 0.45 deg/s (0.3*3/2)

That way you can set continuous speed and folow objects with a tempo you desire. I'm testing it now and it seems the idea works.

Let me know if you are interested.

By the time I want to ask, if it is possible to change rate without requesting slew again - I couldnt figure the other way than sending rate and then immediatelly requesting slew, so two serial writes, possibly not needed.

