### PR TITLE
Use CONFIG_IDF_TARGET_ESP32C3 for ESP32 C3 checks

### DIFF
--- a/src/HAL/esp/ESP32Libraries2.h
+++ b/src/HAL/esp/ESP32Libraries2.h
@@ -90,7 +90,7 @@
 // a really short fixed delay (none needed)
 #define HAL_DELAY_25NS()
 
-#ifdef ARDUINO_ESP32C3_DEV
+#ifdef CONFIG_IDF_TARGET_ESP32C3
   // stand-in for delayNanoseconds(), assumes 80MHz clock
   #define delayNanoseconds(ns) { unsigned int c = ESP.getCycleCount() + ns/12.5F; do {} while ((int)(ESP.getCycleCount() - c) < 0); }
 #else

--- a/src/HAL/esp/ESP32Libraries3.h
+++ b/src/HAL/esp/ESP32Libraries3.h
@@ -81,7 +81,7 @@
 // a really short fixed delay (none needed)
 #define HAL_DELAY_25NS()
 
-#ifdef ARDUINO_ESP32C3_DEV
+#ifdef CONFIG_IDF_TARGET_ESP32C3
   // stand-in for delayNanoseconds(), assumes 80MHz clock
   #define delayNanoseconds(ns) { unsigned int c = ESP.getCycleCount() + ns/12.5F; do {} while ((int)(ESP.getCycleCount() - c) < 0); }
 #else


### PR DESCRIPTION
This checks for all C3 based board, not just the devkit (personaly I'm using the C3 zero, which has another define).
