### PR TITLE
Allow input mode configuration

### DIFF
--- a/SmartHandController.ino
+++ b/SmartHandController.ino
@@ -48,8 +48,15 @@
 #endif
 
 const char Version[] = "Version " FirmwareVersionMajor "." FirmwareVersionMinor FirmwareVersionPatch;
-const int pin[7] = {B_PIN0, B_PIN1, B_PIN2, B_PIN3, B_PIN4, B_PIN5, B_PIN6};
-const int active[7] = {B_PIN0_ACTIVE_STATE, B_PIN1_ACTIVE_STATE, B_PIN2_ACTIVE_STATE, B_PIN3_ACTIVE_STATE, B_PIN4_ACTIVE_STATE, B_PIN5_ACTIVE_STATE, B_PIN6_ACTIVE_STATE};
+const KeyPad::Pin pins[7]= {
+  {B_PIN0, B_PIN0_ACTIVE_STATE, B_PIN0_INPUT_MODE},
+  {B_PIN1, B_PIN1_ACTIVE_STATE, B_PIN1_INPUT_MODE},
+  {B_PIN2, B_PIN2_ACTIVE_STATE, B_PIN2_INPUT_MODE},
+  {B_PIN3, B_PIN3_ACTIVE_STATE, B_PIN3_INPUT_MODE},
+  {B_PIN4, B_PIN4_ACTIVE_STATE, B_PIN4_INPUT_MODE},
+  {B_PIN5, B_PIN5_ACTIVE_STATE, B_PIN5_INPUT_MODE},
+  {B_PIN6, B_PIN6_ACTIVE_STATE, B_PIN6_INPUT_MODE},
+};
 
 void systemServices() {
   nv.poll();
@@ -88,7 +95,7 @@ void setup(void) {
   VF("MSG: Setup, starting system services task (rate 10ms priority 7)... ");
   if (tasks.add(10, 0, true, 7, systemServices, "SysSvcs")) { VL("success"); } else { VL("FAILED!"); }
 
-  userInterface.init(Version, pin, active, SERIAL_ONSTEP_BAUD_DEFAULT, static_cast<OLED>(DISPLAY_OLED));
+  userInterface.init(Version, pins, SERIAL_ONSTEP_BAUD_DEFAULT, static_cast<OLED>(DISPLAY_OLED));
 
   #if WEATHER != OFF
     // get any BME280 or BMP280 ready

--- a/src/libApp/keyPad/KeyPad.cpp
+++ b/src/libApp/keyPad/KeyPad.cpp
@@ -2,29 +2,29 @@
 // Button pad
 #include "KeyPad.h"
 
-void KeyPad::init(const int pin[7], const int active[7], int thresholdNS, int thresholdEW) {
+void KeyPad::init(const Pin pins[7], int thresholdNS, int thresholdEW) {
   if (ready) return;
 
   if (thresholdNS == 0 && thresholdEW == 0) {
-    shift = new Button(pin[0], INPUT_PULLUP, active[0] | HYST(debounceMs));
-    n     = new Button(pin[1], INPUT_PULLUP, active[1] | HYST(debounceMs));
-    s     = new Button(pin[2], INPUT_PULLUP, active[2] | HYST(debounceMs));
-    e     = new Button(pin[3], INPUT_PULLUP, active[3] | HYST(debounceMs));
-    w     = new Button(pin[4], INPUT_PULLUP, active[4] | HYST(debounceMs));
-    F     = new Button(pin[5], INPUT_PULLUP, active[5] | HYST(debounceMs));
-    f     = new Button(pin[6], INPUT_PULLUP, active[6] | HYST(debounceMs));
+    shift = new Button(pins[0].pinNumber, pins[0].inputMode, pins[0].activeState | HYST(debounceMs));
+    n     = new Button(pins[1].pinNumber, pins[1].inputMode, pins[1].activeState | HYST(debounceMs));
+    s     = new Button(pins[2].pinNumber, pins[2].inputMode, pins[2].activeState | HYST(debounceMs));
+    e     = new Button(pins[3].pinNumber, pins[3].inputMode, pins[3].activeState | HYST(debounceMs));
+    w     = new Button(pins[4].pinNumber, pins[4].inputMode, pins[4].activeState | HYST(debounceMs));
+    F     = new Button(pins[5].pinNumber, pins[5].inputMode, pins[5].activeState | HYST(debounceMs));
+    f     = new Button(pins[6].pinNumber, pins[6].inputMode, pins[6].activeState | HYST(debounceMs));
   } else {
-    int active1 = active[1];
-    int active3 = active[3];
+    int active1 = pins[1].activeState;
+    int active3 = pins[3].activeState;
     if (active1 == LOW) active1 = HIGH; else if (active1 == HIGH) active1 = LOW;
     if (active3 == LOW) active3 = HIGH; else if (active3 == HIGH) active3 = LOW;
-    shift = new Button(pin[0], INPUT_PULLUP, active[0] | HYST(debounceMs));
-    n     = new Button(pin[1], INPUT_PULLUP, active1   | THLD(thresholdNS) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
-    s     = new Button(pin[2], INPUT_PULLUP, active[2] | THLD(thresholdNS) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
-    e     = new Button(pin[3], INPUT_PULLUP, active3   | THLD(thresholdEW) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
-    w     = new Button(pin[4], INPUT_PULLUP, active[4] | THLD(thresholdEW) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
-    F     = new Button(pin[5], INPUT_PULLUP, active[5] | HYST(debounceMs));
-    f     = new Button(pin[6], INPUT_PULLUP, active[6] | HYST(debounceMs));
+    shift = new Button(pins[0].pinNumber, pins[0].inputMode, pins[0].activeState | HYST(debounceMs));
+    n     = new Button(pins[1].pinNumber, pins[1].inputMode, active1   | THLD(thresholdNS) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
+    s     = new Button(pins[2].pinNumber, pins[2].inputMode, pins[2].activeState | THLD(thresholdNS) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
+    e     = new Button(pins[3].pinNumber, pins[3].inputMode, active3   | THLD(thresholdEW) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
+    w     = new Button(pins[4].pinNumber, pins[4].inputMode, pins[4].activeState | THLD(thresholdEW) | HYST(KEYPAD_JOYSTICK_HYSTERESIS));
+    F     = new Button(pins[5].pinNumber, pins[5].inputMode, pins[5].activeState | HYST(debounceMs));
+    f     = new Button(pins[6].pinNumber, pins[6].inputMode, pins[6].activeState | HYST(debounceMs));
   }
 
   ready = true;

--- a/src/libApp/keyPad/KeyPad.h
+++ b/src/libApp/keyPad/KeyPad.h
@@ -7,7 +7,12 @@
 
 class KeyPad {
 public:
-  void init(const int pin[7], const int active[7], int thresholdNS, int thresholdEW);
+  struct Pin {
+    int pinNumber;
+    int activeState;
+    int inputMode;
+  };
+  void init(const Pin pins[7], int thresholdNS, int thresholdEW);
 
   void poll();
   bool anyPressed();

--- a/src/pinmaps/Models.h
+++ b/src/pinmaps/Models.h
@@ -33,6 +33,28 @@
   #define B_PIN6_ACTIVE_STATE LOW
 #endif
 
+#ifndef B_PIN0_INPUT_MODE
+  #define B_PIN0_INPUT_MODE INPUT_PULLUP
+#endif
+#ifndef B_PIN1_INPUT_MODE
+  #define B_PIN1_INPUT_MODE INPUT_PULLUP
+#endif
+#ifndef B_PIN2_INPUT_MODE
+  #define B_PIN2_INPUT_MODE INPUT_PULLUP
+#endif
+#ifndef B_PIN3_INPUT_MODE
+  #define B_PIN3_INPUT_MODE INPUT_PULLUP
+#endif
+#ifndef B_PIN4_INPUT_MODE
+  #define B_PIN4_INPUT_MODE INPUT_PULLUP
+#endif
+#ifndef B_PIN5_INPUT_MODE
+  #define B_PIN5_INPUT_MODE INPUT_PULLUP
+#endif
+#ifndef B_PIN6_INPUT_MODE
+  #define B_PIN6_INPUT_MODE INPUT_PULLUP
+#endif
+
 // Default button debounce in milliseconds
 #ifndef BUTTON_DEBOUNCE_MS
   #define BUTTON_DEBOUNCE_MS 30

--- a/src/userInterface/UserInterface.cpp
+++ b/src/userInterface/UserInterface.cpp
@@ -19,7 +19,7 @@ void keyPadWrapper() { keyPad.poll(); }
   void auxST4Wrapper() { auxST4.poll(); }
 #endif
 
-void UI::init(const char version[], const int pin[7], const int active[7], const int SerialBaud, const OLED model) {
+void UI::init(const char version[], const KeyPad::Pin pins[7], const int SerialBaud, const OLED model) {
   serialBaud = SerialBaud;
 
   // get nv ready
@@ -58,7 +58,7 @@ void UI::init(const char version[], const int pin[7], const int active[7], const
     int thresholdNS = analogRead(B_PIN3);
     keyPad.init(pin, active, thresholdNS, thresholdEW);
   #else
-    keyPad.init(pin, active, 0, 0);
+    keyPad.init(pins, 0, 0);
   #endif
   VF("MSG: UserInterface, start KeyPad monitor task (rate 10ms priority 1)... ");
   if (tasks.add(10, 0, true, 1, keyPadWrapper, "Keypad")) { VLF("success"); } else { VLF("FAILED!"); }

--- a/src/userInterface/UserInterface.h
+++ b/src/userInterface/UserInterface.h
@@ -48,7 +48,7 @@ typedef struct DisplaySettings {
 
 class UI {
 public:
-  void init(const char version[], const int pin[7], const int active[7], const int SerialBaud, const OLED model);
+  void init(const char version[], const KeyPad::Pin pins[7], const int SerialBaud, const OLED model);
 
   void connect();
   void drawIntro();


### PR DESCRIPTION
In `Models.h` it is currently possible to configure the active state,  by default they're all `LOW`.
However, if I configure the active state to be `HIGH` instead, this is not going to work, as in `Keypad.cpp` the button pins are configured as `INPUT_PULLUP`.

To make the code a bit cleaner, I added a `Pin` struct, so that instead of passing 2 (before) and 3 (after this change) array of ints, we can just pass a single array of structs.