### PR TITLE
Flush serial ports after sending commands

### DIFF
--- a/src/libApp/cmd/Cmd.cpp
+++ b/src/libApp/cmd/Cmd.cpp
@@ -15,6 +15,7 @@ bool OnStepCmd::processCommand(const char* cmd, char* response, long timeOutMs) 
       SERIAL_IP.setTimeout(timeOutMs);
       while (SERIAL_IP.available() > 0) SERIAL_IP.read();
       SERIAL_IP.print(cmd);
+      SERIAL_IP.flush();
     }
   #endif
   #if SERIAL_BT_MODE != OFF
@@ -23,6 +24,7 @@ bool OnStepCmd::processCommand(const char* cmd, char* response, long timeOutMs) 
       SERIAL_BT.setTimeout(timeOutMs);
       while (SERIAL_BT.available() > 0) SERIAL_BT.read();
       SERIAL_BT.print(cmd);
+      SERIAL_BT.flush();
     }
   #endif
   #if SERIAL_ONSTEP != OFF
@@ -31,6 +33,7 @@ bool OnStepCmd::processCommand(const char* cmd, char* response, long timeOutMs) 
       SERIAL_ONSTEP.setTimeout(timeOutMs);
       while (SERIAL_ONSTEP.available() > 0) SERIAL_ONSTEP.read();
       SERIAL_ONSTEP.print(cmd);
+      SERIAL_ONSTEP.flush();
     }
   #endif
 


### PR DESCRIPTION
After the latest updates my remote could connect to the OnStep mount, but failed to send/process most commands, in the terminal I would only see a timeout in receiving a response.

Initially I thought that the problem was receiving characters, but it looks like the main missing link is a second flush after sending the command. After uploading this version, the connection appears to be flawless.